### PR TITLE
Support for different islands (locations outside of the main island)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 # FiveM Nearby Respawn System
 
 This script tries to revive a player near a "safe" location. The goal is to create a respawn that works similar to GTA5 Online. Currently it should work 99.9% of the time.
-1. The script gathers 20 potential spawn locations near the player's death coordinates and groups them by traffic density.
+1. The script gathers 20 potential spawn locations near the player's death coordinates and groups them by traffic density, it only considers nodes that are on the ground (for the client side)
 2. The script evaluates the traffic density of each potential spawn location and prioritizes those with lower traffic density.
 3. For each potential spawn location, the script checks if it can find a safe spot for the player to respawn, looking for safe coordinates for pedestrians.
 4. If a safe pedestrian path is not found, the script saves the location as a backup option for later consideration.
 5. The script selects the best spawn location based on the lowest traffic density and availability of a safe pedestrian path, defaulting to a backup if necessary.
 6. If no suitable spawn point is found within a certain number of attempts, the script adjusts the search parameters by moving closer to the center of the map. Up to 50 attempts are made to find a suitable spawn point.
-7. If the selected spawn point is in a special area like North Yankton, the script redirects the spawn location to a safe predefined point.
-8. The script checks if the selected location is too close to the player's death coordinates and tries all other backup locations if necessary.
-9. If the script can't find a suitable respawn point after all attempts, it recursively calls itself with a larger search radius and increased depth control to avoid infinite loops (up to 10 recursive calls).
+7. The script checks if the selected location is too close to the player's death coordinates and tries all other backup locations if necessary.
+8. If the script can't find a suitable respawn point after all attempts, it recursively calls itself with a larger search radius and increased depth control to avoid infinite loops (up to 10 recursive calls).
 10. Once a suitable location is found, the script respawns the player at this location with the appropriate orientation, ensuring the player faces towards the road. If no suitable location is found, the player respawns at (0, 0, 70) (This list of backup locations can be expanded in `client.lua`).
 
 Debug Prints and Blips are also available, by changing the bools in `client.lua`.
@@ -22,17 +21,26 @@ Debug Prints and Blips are also available, by changing the bools in `client.lua`
 
 | Color       |  Meaning |
 |-------------|----------|
-| Dark gray   | Death Point |
+| Dark gray   | Death Point or new Death Point(s) (if the player died outside of the map) |
 | Yellow/Gold | Respawn Point |
 | Green       | Safe Respawn Point (Footpath, Walkway, etc.) |
 | Blue        | Backup Respawn Point (Roads with no footpaths, high density roads) |
 | Red         | Too close to the Death Point |
 
 ## Installation:
-1. Download this repository and extract it to your resources folder. **NOTE:** This script requires the `spawnmanager` resource to be running. 
+1. Download this repository and extract it to your resources folder. **NOTE:** This script requires the `spawnmanager` resource to be running. E.g. the folder structure should look like this:
+    ```
+    [resources]
+        -> [fivem-respawn-nearby]
+            -> [client.lua]
+            ...
+    ```
 2. Add `ensure nearby-respawn` to your server.cfg. Make sure that `spawnmanager` is ensured **before** `nearby-respawn`.
-1. Done. You should now be able to respawn nearby your death location.
+    ```
+    ensure spawnmanager
+    ensure nearby-respawn
+    ```
+3. Done. You should now be able to respawn nearby your death location.
 
 ## Known Issues:
-* You **rarely** respawn inside of an bunker entrance (Maybe also other dlc content, eg. facilities)
-* This system only supports the main island of GTA5 (Los Santos). North Yankton, Cayo Perico, etc. are not supported. (WIP)
+* You **rarely** respawn inside of an bunker entrance (Maybe also other dlc content, eg. facilities) (Needs Testing)

--- a/client.lua
+++ b/client.lua
@@ -16,11 +16,17 @@ DEBUG_BLIPS = false
 
 -- https://docs.fivem.net/docs/resources/baseevents/events/onPlayerDied/
 AddEventHandler('baseevents:onPlayerDied', function(killerType, deathCoords)
+	if (deathCoords == nil) then
+		deathCoords = GetEntityCoords(PlayerPedId())
+	end
 	handleDeath(deathCoords)
 end)
 
 -- https://docs.fivem.net/docs/resources/baseevents/events/onPlayerKilled/
 AddEventHandler('baseevents:onPlayerKilled', function(killerId, deathData)
+	if (deathData.deathCoords == nil) then
+		deathData.deathCoords = GetEntityCoords(PlayerPedId())
+	end
 	handleDeath(deathData.deathCoords)
 end)
 
@@ -286,3 +292,5 @@ exports.spawnmanager:setAutoSpawn(false)
 -- Exports
 exports("Respawn", Respawn)
 exports("GetRespawnCoords", GetRespawnCoords)
+
+Respawn(GetEntityCoords(PlayerPedId()), GetEntityHeading(PlayerPedId()), GetEntityModel(PlayerPedId()))

--- a/client.lua
+++ b/client.lua
@@ -1,28 +1,40 @@
-RESPAWN_RADIUS = 75     -- default 75
+RESPAWN_RADIUS = 75     -- default 75 (higher value = more likely to spawn further away from death point)
 RESPAWN_DELAY = 5       -- seconds (def. 5)
 BACKUP_RESPAWN_POINTS = {
-	{ x = 0, y = 0, z = 70 } --TODO: Add more backup respawn points (only in or near city)
+	{ x = 0, y = 0, z = 70 } -- TODO: Expand me
 }
 INIT_PLAYER_MODELS = {
 	"a_m_y_skater_01",
 	"a_m_y_skater_02",
 	"a_m_y_stbla_01",
 	"a_m_y_stbla_02"
-}
+} -- TODO: Expand me
 
 BLIPS = {}
 DEBUG_PRINT = false
 DEBUG_BLIPS = false
 
--- https://docs.fivem.net/docs/resources/baseevents/events/onPlayerWasted/
-AddEventHandler('baseevents:onPlayerWasted', function(deathCoords)
-	clearBlips()
-	local deathCoords, deathRotation, modelAfterDeath = GetRespawnCoords(deathCoords, RESPAWN_RADIUS, 0)
-	local gameTimer = GetGameTimer()
-	Wait(math.max((RESPAWN_DELAY * 1000) - (GetGameTimer() - gameTimer), 0))
-	Respawn(deathCoords, deathRotation, modelAfterDeath)
-	ClearPedBloodDamage(GetPlayerPed(-1))
+-- https://docs.fivem.net/docs/resources/baseevents/events/onPlayerDied/
+AddEventHandler('baseevents:onPlayerDied', function(killerType, deathCoords)
+	handleDeath(deathCoords)
 end)
+
+-- https://docs.fivem.net/docs/resources/baseevents/events/onPlayerKilled/
+AddEventHandler('baseevents:onPlayerKilled', function(killerId, deathData)
+	handleDeath(deathData.deathCoords)
+end)
+
+function handleDeath(deathCoords)
+	clearBlips()
+	Wait(RESPAWN_DELAY * 1000)
+	DoScreenFadeOut(500);
+	while not IsScreenFadedOut() do
+		Wait(0)
+	end
+	local respawnCoords = GetRespawnCoords(deathCoords, RESPAWN_RADIUS, 0)
+	Respawn(respawnCoords)
+	ClearPedBloodDamage(GetPlayerPed(-1))
+end
 
 function clearBlips()
 	for i, blip in ipairs(BLIPS) do
@@ -45,6 +57,12 @@ function showBlipIfDebug(coords, color, text)
 	EndTextCommandSetBlipName(blip)
 end
 
+function printDebug(text)
+	if (DEBUG_PRINT) then
+		print("[DEBUG]: " .. text)
+	end
+end
+
 function GetRespawnCoords(deathCoords, radius, _depth)
 	local playerModel = GetEntityModel(PlayerPedId())
 	if (_depth > 10) then
@@ -54,9 +72,7 @@ function GetRespawnCoords(deathCoords, radius, _depth)
 	end
 
 	local death_x, death_y, death_z = table.unpack(deathCoords)
-	if (DEBUG_PRINT) then
-		print("[DEBUG]: GetRespawnCoords called with deathCoords: [" .. death_x .. ", " .. death_y .. ", " .. death_z .. "], radius: " .. radius)
-	end
+	printDebug("GetRespawnCoords called with deathCoords: [" .. death_x .. ", " .. death_y .. ", " .. death_z .. "], radius: " .. radius)
 	local newPos = BACKUP_RESPAWN_POINTS[math.random(1, #BACKUP_RESPAWN_POINTS)]
 	local newRot = math.random(0, 360)
 	local maxIterations = 50
@@ -69,23 +85,23 @@ function GetRespawnCoords(deathCoords, radius, _depth)
 	while (not footpath_found) and counter < maxIterations do
 
 		local possibleSpawns = {}
-		for _i = 1, 20 do
-			local closeNode = GetNthClosestVehicleNodeId(death_x, death_y, death_z, math.random(0, radius), 1, 300.0, 300.0)
-			if closeNode ~= 0 then
-				local roadNodePos = GetVehicleNodePosition(closeNode)
-
+		local nOffset = math.random(1, radius)
+		for i = 1, 20 do
+			local foundNode, nodePos = GetNthClosestVehicleNode(death_x, death_y, death_z, nOffset + (i-1), 1, 3, 0)
+			if foundNode then				
 				-- save node and grouped by density
-				local succ, density, _flags = GetVehicleNodeProperties(roadNodePos.x, roadNodePos.y, roadNodePos.z)
+				local succ, density, _flags = GetVehicleNodeProperties(nodePos.x, nodePos.y, nodePos.z)
 				if (succ) then
 					if not possibleSpawns[density] then
 						possibleSpawns[density] = {}
 					end
-					possibleSpawns[density][#possibleSpawns[density]+1] = roadNodePos
+					possibleSpawns[density][#possibleSpawns[density]+1] = nodePos
 				end
 			end
 		end
 
-		if (#possibleSpawns > 0) then
+		if (next(possibleSpawns) ~= nil) then
+			print("[DEBUG]: Possible spawns found: " .. #possibleSpawns)
 			-- if any possibleSpawns found, choose the one with lowest density but only if a safe coord was found (footpath)
 			local densities = {}
 			for k, v in pairs(possibleSpawns) do
@@ -105,14 +121,19 @@ function GetRespawnCoords(deathCoords, radius, _depth)
 							succ, footpathPos = GetSafeCoordForPed(possibleSpawn.x, possibleSpawn.y, possibleSpawn.z, false, 16)
 						end
 
+						local onGround, _ = GetGroundZFor_3dCoord(footpathPos.x, footpathPos.y, footpathPos.z, 0)
 						if (succ) then
-							footpath_found = true
-							newPos = footpathPos
-							newRot = GetHeadingFromVector_2d(footpathPos.x - possibleSpawn.x, footpathPos.y - possibleSpawn.y) -- face towards road
-							showBlipIfDebug(footpathPos, 2, "Footpath") -- green
+							showBlipIfDebug(footpathPos, 2, "Footpath (onGround: " .. tostring(onGround) .. ")") -- green
+							if (onGround) then
+								footpath_found = true
+								newPos = footpathPos
+								newRot = GetHeadingFromVector_2d(footpathPos.x - possibleSpawn.x, footpathPos.y - possibleSpawn.y) -- face towards road
+							end
 						else
-							backups[#backups+1] = possibleSpawn
-							showBlipIfDebug(possibleSpawn, 3, "Backup") -- blue
+							showBlipIfDebug(possibleSpawn, 3, "Backup (onGround: " .. tostring(onGround) .. ")") -- blue
+							if (onGround) then
+								backups[#backups+1] = possibleSpawn
+							end
 						end
 					end
 				end
@@ -124,74 +145,114 @@ function GetRespawnCoords(deathCoords, radius, _depth)
 		end
 
 		if (#backups > 0) then -- if no footpath found, use backup
-			newPos = backups[1] -- take first (lowest density) backup
+			newPos = backups[1]
 			footpath_found = true
-			if (DEBUG_PRINT) then
-				print("[DEBUG]: Backup used")
-			end
-			break
-		else 
-			-- if backups empty, slowly get closer to the center of the map and try again
-			local absX = math.abs(death_x)
-			local absY = math.abs(death_y)
-			if absX >= absY then 
-				death_x = death_x * 0.75
-			elseif absY > absX then
-				death_y = death_y * 0.75
-			end
-			if (counter > maxIterations / 2) then
-				radius = math.floor(math.max(radius * 0.9, 1))
-			end
+			showBlipIfDebug(newPos, 3, "Backup") -- blue
+			printDebug("Backup used")
+		end
 
-			if (DEBUG_PRINT) then
-				print("[DEBUG]: No nodes found, trying again with goint closer to center...")
-				print("[DEBUG]: New Death Coords: [" .. death_x .. ", " .. death_y .. ", " .. death_z .. "]")
-				print("[DEBUG]: New Radius: " .. radius)
+		if (footpath_found) then
+			break
+		end
+
+		-- if backups empty or no safe point found, slowly get closer to the center of the map and try again
+		local newDeath_x, newDeath_y = death_x, death_y	
+		if (death_x > 0) then
+			newDeath_x = math.max(death_x - 250, 0)
+		else
+			newDeath_x = math.min(death_x + 250, 0)
+		end
+
+		if (death_y > 0) then
+			newDeath_y = math.max(death_y - 250, 0)
+		else
+			newDeath_y = math.min(death_y + 250, 0)
+		end
+
+		local newDeath_z = death_z
+		for zz = 950, 0, -25 do
+			local z = zz
+			
+			if (z % 2 == 1) then
+				z = 950 - zz -- search each 2nd iteration from the bottom instead from the top
+			end
+	
+			SetFocusPosAndVel(newDeath_x, newDeath_y, z, 0, 0, 0)
+	
+			local startTime = GetGameTimer()
+			if NewLoadSceneStart(newDeath_x, newDeath_y, z, 0, 0, 0, 50.0, 0) then
+				while not IsNewLoadSceneLoaded() and GetGameTimer() - startTime < 3000 do
+					Wait(0)
+				end
+				ClearFocus()
+				NewLoadSceneStop()
+	
+				SetEntityCoords(PlayerPedId(), newDeath_x, newDeath_y, z, false, false, false, true)
+	
+				startTime = GetGameTimer()
+				while not HasCollisionLoadedAroundEntity(PlayerPedId()) and GetGameTimer() - startTime < 1000 do
+					Wait(0)
+				end
+	
+				hasGround, _ = GetGroundZFor_3dCoord(newDeath_x, newDeath_y, z, 0)
+				if (hasGround) then
+					newDeath_z = z
+					break
+				end
 			end
 		end
+
+		death_x, death_y, death_z = newDeath_x, newDeath_y, newDeath_z
+
+		if (counter > maxIterations / 2) then
+			radius = math.floor(math.max(radius * 0.9, 1))
+		end
+
+		printDebug("No nodes found, trying again with going closer to center...")
+		printDebug("New Death Coords: [" .. death_x .. ", " .. death_y .. ", " .. death_z .. "]")
+		printDebug("New Radius: " .. radius)
+		local densString = ""
+		if (#possibleSpawns > 0) then
+			for k, v in pairs(possibleSpawns) do
+				densString = densString .. k .. ":" .. #v .. ", "
+			end
+		else
+			densString = "Empty"
+		end
+		printDebug("Densities: " .. densString)
+
+		showBlipIfDebug(vector3(death_x, death_y, death_z), 40, "New Death Coords (going closer)") -- dark gray
+
 		counter = counter + 1
 	end
-	if (DEBUG_PRINT) then
-		print("[DEBUG]: Iterations: " .. counter)
-		print("[DEBUG]: Final Death Coords: [" .. death_x .. ", " .. death_y .. ", " .. death_z .. "]")
-	end
 
-	-- North Yankton check (TODO: Check if north yankton is loaded)
-	if newPos.x > 2750 and newPos.y < -4500 then
-		newPos = vector3(1285.0, -3339.0, 6.0) -- Port (nearest Point)
-		if (DEBUG_PRINT) then
-			print("[DEBUG]: North Yankton detected, teleporting to port...")
-		end
-	end
+	printDebug("-----------------------------------")
+	printDebug("Iterations: " .. counter)
+	printDebug("Final Death Coords: [" .. death_x .. ", " .. death_y .. ", " .. death_z .. "]")
 
 	-- check if respawn point is too close to deathCoords, if so call GetRespawnCoords with higherRadius
 	local org_death_x, org_death_y, org_death_z = table.unpack(deathCoords)
 	local distance = math.sqrt((org_death_x - newPos.x) ^ 2 + (org_death_y - newPos.y) ^ 2)
-	if (DEBUG_PRINT) then
-		print("[DEBUG]: Distance to deathCoords: " .. string.format("%.2f", distance))
-	end
+	printDebug("Distance to deathCoords: " .. string.format("%.2f", distance))
 	counter = 1
-	while distance < RESPAWN_RADIUS and counter+1 < #backups do
-		if (DEBUG_PRINT) then
-			print("[DEBUG]: Too close to deathCoords, trying backups...")
-		end
-		showBlipIfDebug(newPos, 1, "Too Close") -- red
+	local onGround = false
+	while distance < RESPAWN_RADIUS and counter+1 < #backups and not onGround do
+		printDebug("Too close to deathCoords, trying backups...")
+		showBlipIfDebug(death_x, death_y, death_z, 1, "Too Close") -- red
 
 		counter = counter + 1
 		newPos = backups[counter]
 		distance = math.sqrt((org_death_x - newPos.x) ^ 2 + (org_death_y - newPos.y) ^ 2)
+		onGround, _ = GetGroundZFor_3dCoord(newPos.x, newPos.y, newPos.z, 0)
 	end
 
 	if (distance < RESPAWN_RADIUS) then
-		if (DEBUG_PRINT) then
-			print("[DEBUG]: Still too close to deathCoords, trying again with higher radius...")
-		end
+		printDebug("Still too close to deathCoords, trying again with higher radius...")
+		
 		return GetRespawnCoords(deathCoords, math.ceil(radius * 1.1), _depth + 1)
 	end
-	if (DEBUG_PRINT) then
-		print("[DEBUG]: Respawn coords: [" .. newPos.x .. ", " .. newPos.y .. ", " .. newPos.z .. "]")
-	end
 
+	printDebug("Respawn coords: [" .. newPos.x .. ", " .. newPos.y .. ", " .. newPos.z .. "]")
 	showBlipIfDebug(newPos, 5, "Respawn Point") -- yellow
 
 	return newPos, newRot, playerModel
@@ -209,7 +270,11 @@ function Respawn(coords, rot, model)
 end
 
 -- Awaiting scripts workaround
-if not NetworkIsPlayerActive(PlayerId()) then -- If the player is not active, respawn them at a random backup point (initial spawn)
+local player = PlayerPedId()
+local playerCoords = GetEntityCoords(player)
+local playerHeading = GetEntityHeading(player)
+local isFalling = IsPedFalling(player)
+if playerCoords.x == 0 and playerCoords.y == 0 and playerCoords.z == 1 and playerHeading == 0 and not isFalling then
 	local randomBackupPoint = BACKUP_RESPAWN_POINTS[math.random(1, #BACKUP_RESPAWN_POINTS)]
 	randomBackupPoint = vector3(randomBackupPoint['x'], randomBackupPoint['y'], randomBackupPoint['z'])
 	Respawn(randomBackupPoint)

--- a/client.lua
+++ b/client.lua
@@ -11,8 +11,8 @@ INIT_PLAYER_MODELS = {
 }
 
 BLIPS = {}
-DEBUG_PRINT = true
-DEBUG_BLIPS = true
+DEBUG_PRINT = false
+DEBUG_BLIPS = false
 
 -- https://docs.fivem.net/docs/resources/baseevents/events/onPlayerDied/
 AddEventHandler('baseevents:onPlayerDied', function(killerType, deathCoords)
@@ -220,11 +220,7 @@ function Respawn(coords, rot, model)
 end
 
 -- Awaiting scripts workaround
-local player = PlayerPedId()
-local playerCoords = GetEntityCoords(player)
-local playerHeading = GetEntityHeading(player)
-local isFalling = IsPedFalling(player)
-if playerCoords.x == 0 and playerCoords.y == 0 and playerCoords.z == 1 and playerHeading == 0 and not isFalling then
+if not NetworkIsPlayerActive(PlayerId()) then -- If the player is not active, respawn them at a random backup point (initial spawn)
 	local randomBackupPoint = BACKUP_RESPAWN_POINTS[math.random(1, #BACKUP_RESPAWN_POINTS)]
 	randomBackupPoint = vector3(randomBackupPoint['x'], randomBackupPoint['y'], randomBackupPoint['z'])
 	Respawn(randomBackupPoint)
@@ -233,5 +229,3 @@ end
 -- Exports
 exports("Respawn", Respawn)
 exports("RespawnNear", RespawnNear)
-
-Respawn(GetEntityCoords(PlayerPedId()), GetEntityHeading(PlayerPedId()), GetEntityModel(PlayerPedId()))

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,10 +4,8 @@ game 'gta5'
 author 'Flamtky'
 description 'Respawn System for nearby respawning, like in GTA Online'
 repository 'https://github.com/flamtky/fivem-respawn-nearby'
-version '1.2.1'
+version '1.3.0'
 
 resource_type 'gametype' { name = 'Freeroam' }
 
 client_script 'client.lua'
-
-gta5_warning 'Work in Progress. Should work 99% of the time.'


### PR DESCRIPTION
* The script now supports locations like North Yankton, Cayo Perico
* The scripts now checks if the loction is "on Ground" (client-sided) before respawning the player
* During the respawn process the screen fades out, to hide preloading collions
* New debugging logs and blips
  * Now the new death loctions (if no possible respawn loctions are found) are getting drawn
  * New logging for more info
* Litte refactoring to prevent Code Duplication
* Debugging is now by default disabled (Prints and Blips)

Tested on version: 3095